### PR TITLE
Package initializer deprecation warning fix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,5 +16,5 @@ let package = Package(
           path: "Sources"
       )
     ],
-    swiftLanguageVersions: [.v5, .v6]
+    swiftLanguageModes: [.v5, .v6]
 )


### PR DESCRIPTION
Use `swiftLanguageModes` instead of `swiftLanguageVersions` in Package initializer to suppress deprecation warning.